### PR TITLE
fix: search title with two or more words

### DIFF
--- a/src/app/service/ApiRequest.ts
+++ b/src/app/service/ApiRequest.ts
@@ -18,7 +18,7 @@ export const defaultOptions: RequestOptions = {
 export function buildQueryString(params: ApiQueryParams) {
   const query = Object.entries(params)
     .filter(([, value]) => value !== undefined)
-    .map(([key, value]) => [key, encodeURIComponent(String(value))]);
+    .map(([key, value]) => [key, String(value)]);
 
   return `?${new URLSearchParams(Object.fromEntries(query)).toString()}`;
 }

--- a/src/app/service/MovieService.ts
+++ b/src/app/service/MovieService.ts
@@ -13,11 +13,7 @@ export const getMoviesByGenre = async (
   genre: string,
   options?: RequestOptions
 ): Promise<Movies> => {
-  return apiRequest(
-    `movies`,
-    { genres_like: encodeURIComponent(genre) },
-    options
-  );
+  return apiRequest(`movies`, { genres_like: genre }, options);
 };
 
 export const searchMovies = async (
@@ -30,8 +26,8 @@ export const searchMovies = async (
   return apiRequest(
     `movies`,
     {
-      title_like: encodeURIComponent(title),
-      genres_like: encodeURIComponent(genre),
+      title_like: title,
+      genres_like: genre,
     },
     options
   );


### PR DESCRIPTION
Movies are not found when searching using two or more words. For example, The Godfather should bring two movies, but none is found.
The "URLSearchParams" encodes the search string appropriately.